### PR TITLE
fix: Allow for passing not the entire preferences object to `savePreferences`

### DIFF
--- a/internal/database/mappers/preferences.go
+++ b/internal/database/mappers/preferences.go
@@ -69,24 +69,58 @@ func PreferencesInputModelToEntity(model models.InputPreferences, entity *entiti
 		return nil
 	}
 
-	entity.EnableAutoSkip = model.EnableAutoSkip
-	entity.EnableAutoPlay = model.EnableAutoPlay
-	entity.MinimizeToolbarWhenEditing = model.MinimizeToolbarWhenEditing
-	entity.HideTimelineWhenMinimized = model.HideTimelineWhenMinimized
+	if model.EnableAutoSkip != nil {
+		entity.EnableAutoSkip = *model.EnableAutoSkip
+	}
+	if model.EnableAutoPlay != nil {
+		entity.EnableAutoPlay = *model.EnableAutoPlay
+	}
+	if model.MinimizeToolbarWhenEditing != nil {
+		entity.MinimizeToolbarWhenEditing = *model.MinimizeToolbarWhenEditing
+	}
+	if model.HideTimelineWhenMinimized != nil {
+		entity.HideTimelineWhenMinimized = *model.HideTimelineWhenMinimized
+	}
 
-	entity.SkipBranding = model.SkipBranding
-	entity.SkipIntros = model.SkipIntros
-	entity.SkipNewIntros = model.SkipNewIntros
-	entity.SkipMixedIntros = model.SkipMixedIntros
-	entity.SkipRecaps = model.SkipRecaps
-	entity.SkipFiller = model.SkipFiller
-	entity.SkipCanon = model.SkipCanon
-	entity.SkipTransitions = model.SkipTransitions
-	entity.SkipCredits = model.SkipCredits
-	entity.SkipNewCredits = model.SkipNewCredits
-	entity.SkipMixedCredits = model.SkipMixedCredits
-	entity.SkipPreview = model.SkipPreview
-	entity.SkipTitleCard = model.SkipTitleCard
+	if model.SkipBranding != nil {
+		entity.SkipBranding = *model.SkipBranding
+	}
+	if model.SkipIntros != nil {
+		entity.SkipIntros = *model.SkipIntros
+	}
+	if model.SkipNewIntros != nil {
+		entity.SkipNewIntros = *model.SkipNewIntros
+	}
+	if model.SkipMixedIntros != nil {
+		entity.SkipMixedIntros = *model.SkipMixedIntros
+	}
+	if model.SkipRecaps != nil {
+		entity.SkipRecaps = *model.SkipRecaps
+	}
+	if model.SkipFiller != nil {
+		entity.SkipFiller = *model.SkipFiller
+	}
+	if model.SkipCanon != nil {
+		entity.SkipCanon = *model.SkipCanon
+	}
+	if model.SkipTransitions != nil {
+		entity.SkipTransitions = *model.SkipTransitions
+	}
+	if model.SkipCredits != nil {
+		entity.SkipCredits = *model.SkipCredits
+	}
+	if model.SkipNewCredits != nil {
+		entity.SkipNewCredits = *model.SkipNewCredits
+	}
+	if model.SkipMixedCredits != nil {
+		entity.SkipMixedCredits = *model.SkipMixedCredits
+	}
+	if model.SkipPreview != nil {
+		entity.SkipPreview = *model.SkipPreview
+	}
+	if model.SkipTitleCard != nil {
+		entity.SkipTitleCard = *model.SkipTitleCard
+	}
 
 	return entity
 }

--- a/internal/graphql/main.go
+++ b/internal/graphql/main.go
@@ -2409,28 +2409,30 @@ type Preferences {
   skipTitleCard: Boolean!
 }
 
-"Data required to update a user's ` + "`" + `Preferences` + "`" + `. See ` + "`" + `Preferences` + "`" + ` for a description of each field"
+"""
+Data used to update a user's ` + "`" + `Preferences` + "`" + `. See ` + "`" + `Preferences` + "`" + ` for a description of each field. If a
+field is not passed or passed as ` + "`" + `null` + "`" + `, it will leave the value as is and skip updating it
+"""
 input InputPreferences {
-  enableAutoSkip: Boolean!
-  enableAutoPlay: Boolean!
-  minimizeToolbarWhenEditing: Boolean!
-  hideTimelineWhenMinimized: Boolean!
+  enableAutoSkip: Boolean
+  enableAutoPlay: Boolean
+  minimizeToolbarWhenEditing: Boolean
+  hideTimelineWhenMinimized: Boolean
 
-  skipBranding: Boolean!
-  skipIntros: Boolean!
-  skipNewIntros: Boolean!
-  skipMixedIntros: Boolean!
-  skipRecaps: Boolean!
-  skipFiller: Boolean!
-  skipCanon: Boolean!
-  skipTransitions: Boolean!
-  skipCredits: Boolean!
-  skipNewCredits: Boolean!
-  skipMixedCredits: Boolean!
-  skipPreview: Boolean!
-  skipTitleCard: Boolean!
+  skipBranding: Boolean
+  skipIntros: Boolean
+  skipNewIntros: Boolean
+  skipMixedIntros: Boolean
+  skipRecaps: Boolean
+  skipFiller: Boolean
+  skipCanon: Boolean
+  skipTransitions: Boolean
+  skipCredits: Boolean
+  skipNewCredits: Boolean
+  skipMixedCredits: Boolean
+  skipPreview: Boolean
+  skipTitleCard: Boolean
 }
-
 
 "A show containing a list of episodes and relevate links"
 type Show implements BaseModel {
@@ -2637,7 +2639,7 @@ type User {
   "Handle a deleteToken from ` + "`" + `deleteAccountRequest` + "`" + ` and actually delete the user's account"
   deleteAccount(deleteToken: String!): Account
 
-  # Prefernces
+  # Preferences
   "Update user preferences"
   savePreferences(preferences: InputPreferences!): Preferences @authorized
 
@@ -12098,7 +12100,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("enableAutoSkip"))
-			it.EnableAutoSkip, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.EnableAutoSkip, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12106,7 +12108,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("enableAutoPlay"))
-			it.EnableAutoPlay, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.EnableAutoPlay, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12114,7 +12116,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("minimizeToolbarWhenEditing"))
-			it.MinimizeToolbarWhenEditing, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.MinimizeToolbarWhenEditing, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12122,7 +12124,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("hideTimelineWhenMinimized"))
-			it.HideTimelineWhenMinimized, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.HideTimelineWhenMinimized, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12130,7 +12132,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipBranding"))
-			it.SkipBranding, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipBranding, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12138,7 +12140,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipIntros"))
-			it.SkipIntros, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipIntros, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12146,7 +12148,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipNewIntros"))
-			it.SkipNewIntros, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipNewIntros, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12154,7 +12156,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipMixedIntros"))
-			it.SkipMixedIntros, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipMixedIntros, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12162,7 +12164,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipRecaps"))
-			it.SkipRecaps, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipRecaps, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12170,7 +12172,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipFiller"))
-			it.SkipFiller, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipFiller, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12178,7 +12180,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipCanon"))
-			it.SkipCanon, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipCanon, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12186,7 +12188,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipTransitions"))
-			it.SkipTransitions, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipTransitions, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12194,7 +12196,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipCredits"))
-			it.SkipCredits, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipCredits, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12202,7 +12204,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipNewCredits"))
-			it.SkipNewCredits, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipNewCredits, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12210,7 +12212,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipMixedCredits"))
-			it.SkipMixedCredits, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipMixedCredits, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12218,7 +12220,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipPreview"))
-			it.SkipPreview, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipPreview, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12226,7 +12228,7 @@ func (ec *executionContext) unmarshalInputInputPreferences(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("skipTitleCard"))
-			it.SkipTitleCard, err = ec.unmarshalNBoolean2bool(ctx, v)
+			it.SkipTitleCard, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/internal/graphql/models/generated.go
+++ b/internal/graphql/models/generated.go
@@ -151,25 +151,26 @@ type InputExistingTimestamp struct {
 	Timestamp *InputTimestamp `json:"timestamp"`
 }
 
-// Data required to update a user's `Preferences`. See `Preferences` for a description of each field
+// Data used to update a user's `Preferences`. See `Preferences` for a description of each field. If a
+// field is not passed or passed as `null`, it will leave the value as is and skip updating it
 type InputPreferences struct {
-	EnableAutoSkip             bool `json:"enableAutoSkip"`
-	EnableAutoPlay             bool `json:"enableAutoPlay"`
-	MinimizeToolbarWhenEditing bool `json:"minimizeToolbarWhenEditing"`
-	HideTimelineWhenMinimized  bool `json:"hideTimelineWhenMinimized"`
-	SkipBranding               bool `json:"skipBranding"`
-	SkipIntros                 bool `json:"skipIntros"`
-	SkipNewIntros              bool `json:"skipNewIntros"`
-	SkipMixedIntros            bool `json:"skipMixedIntros"`
-	SkipRecaps                 bool `json:"skipRecaps"`
-	SkipFiller                 bool `json:"skipFiller"`
-	SkipCanon                  bool `json:"skipCanon"`
-	SkipTransitions            bool `json:"skipTransitions"`
-	SkipCredits                bool `json:"skipCredits"`
-	SkipNewCredits             bool `json:"skipNewCredits"`
-	SkipMixedCredits           bool `json:"skipMixedCredits"`
-	SkipPreview                bool `json:"skipPreview"`
-	SkipTitleCard              bool `json:"skipTitleCard"`
+	EnableAutoSkip             *bool `json:"enableAutoSkip"`
+	EnableAutoPlay             *bool `json:"enableAutoPlay"`
+	MinimizeToolbarWhenEditing *bool `json:"minimizeToolbarWhenEditing"`
+	HideTimelineWhenMinimized  *bool `json:"hideTimelineWhenMinimized"`
+	SkipBranding               *bool `json:"skipBranding"`
+	SkipIntros                 *bool `json:"skipIntros"`
+	SkipNewIntros              *bool `json:"skipNewIntros"`
+	SkipMixedIntros            *bool `json:"skipMixedIntros"`
+	SkipRecaps                 *bool `json:"skipRecaps"`
+	SkipFiller                 *bool `json:"skipFiller"`
+	SkipCanon                  *bool `json:"skipCanon"`
+	SkipTransitions            *bool `json:"skipTransitions"`
+	SkipCredits                *bool `json:"skipCredits"`
+	SkipNewCredits             *bool `json:"skipNewCredits"`
+	SkipMixedCredits           *bool `json:"skipMixedCredits"`
+	SkipPreview                *bool `json:"skipPreview"`
+	SkipTitleCard              *bool `json:"skipTitleCard"`
 }
 
 // Data required to create a new `Show`. See `Show` for a description of each field

--- a/internal/graphql/schemas/models.graphql
+++ b/internal/graphql/schemas/models.graphql
@@ -260,28 +260,30 @@ type Preferences {
   skipTitleCard: Boolean!
 }
 
-"Data required to update a user's `Preferences`. See `Preferences` for a description of each field"
+"""
+Data used to update a user's `Preferences`. See `Preferences` for a description of each field. If a
+field is not passed or passed as `null`, it will leave the value as is and skip updating it
+"""
 input InputPreferences {
-  enableAutoSkip: Boolean!
-  enableAutoPlay: Boolean!
-  minimizeToolbarWhenEditing: Boolean!
-  hideTimelineWhenMinimized: Boolean!
+  enableAutoSkip: Boolean
+  enableAutoPlay: Boolean
+  minimizeToolbarWhenEditing: Boolean
+  hideTimelineWhenMinimized: Boolean
 
-  skipBranding: Boolean!
-  skipIntros: Boolean!
-  skipNewIntros: Boolean!
-  skipMixedIntros: Boolean!
-  skipRecaps: Boolean!
-  skipFiller: Boolean!
-  skipCanon: Boolean!
-  skipTransitions: Boolean!
-  skipCredits: Boolean!
-  skipNewCredits: Boolean!
-  skipMixedCredits: Boolean!
-  skipPreview: Boolean!
-  skipTitleCard: Boolean!
+  skipBranding: Boolean
+  skipIntros: Boolean
+  skipNewIntros: Boolean
+  skipMixedIntros: Boolean
+  skipRecaps: Boolean
+  skipFiller: Boolean
+  skipCanon: Boolean
+  skipTransitions: Boolean
+  skipCredits: Boolean
+  skipNewCredits: Boolean
+  skipMixedCredits: Boolean
+  skipPreview: Boolean
+  skipTitleCard: Boolean
 }
-
 
 "A show containing a list of episodes and relevate links"
 type Show implements BaseModel {

--- a/internal/graphql/schemas/mutations.graphql
+++ b/internal/graphql/schemas/mutations.graphql
@@ -20,7 +20,7 @@ type Mutation {
   "Handle a deleteToken from `deleteAccountRequest` and actually delete the user's account"
   deleteAccount(deleteToken: String!): Account
 
-  # Prefernces
+  # Preferences
   "Update user preferences"
   savePreferences(preferences: InputPreferences!): Preferences @authorized
 


### PR DESCRIPTION
As more and more preferences get added, it is impossible to keep the request the web extension makes in sync with the backend changes

Since all preferences are required fields, not including them in the request is equivelent to not setting them. This would not work for objects with optional fields, since it would be ambinguous if they wanted to leave that field alone or if they want to set it to `null`