### PR TITLE
fix: only return templates the user created

### DIFF
--- a/api/queries.graphqls
+++ b/api/queries.graphqls
@@ -97,9 +97,19 @@ type Query {
   allTimestampTypes: [TimestampType!]!
 
   # Templates
-  "Get template info based on a `Template.id`"
+  """
+  Get template info based on a `Template.id`
+
+  Only templates you've created are returned. If you don't pass auth to this method, it will an
+  error saying not found.
+  """
   findTemplate(templateId: ID!): Template!
-  "Get a list of templates based on the `Template.showId`"
+  """
+  Get a list of templates based on the `Template.showId`
+
+  Only templates you've created are returned. If you don't pass auth to this method, it will an
+  error saying not found.
+  """
   findTemplatesByShowId(showId: ID!): [Template!]!
   """
   Find the most relevant template based on a few search criteria. If multiple templates are found,
@@ -108,6 +118,9 @@ type Query {
   1. Matching `sourceEpisodeID`
   2. Matching show name (case sensitive) and season (case sensitive)
   3. Matching show name (case sensitive)
+
+  Only templates you've created are returned. If you don't pass auth to this method, it will an
+  error saying not found.
   """
   findTemplateByDetails(
     episodeId: ID

--- a/api/queries.graphqls
+++ b/api/queries.graphqls
@@ -108,7 +108,7 @@ type Query {
   Get a list of templates based on the `Template.showId`
 
   Only templates you've created are returned. If you don't include a token in the authorization
-  header, you will receive an empty list
+  header, you will receive an empty list.
   """
   findTemplatesByShowId(showId: ID!): [Template!]!
   """

--- a/api/queries.graphqls
+++ b/api/queries.graphqls
@@ -100,15 +100,15 @@ type Query {
   """
   Get template info based on a `Template.id`
 
-  Only templates you've created are returned. If you don't pass auth to this method, it will an
-  error saying not found.
+  Only templates you've created are returned. If you don't include a token in the authorization
+  header, you will get a not found error, same as if the template was not found.
   """
   findTemplate(templateId: ID!): Template!
   """
   Get a list of templates based on the `Template.showId`
 
-  Only templates you've created are returned. If you don't pass auth to this method, it will an
-  error saying not found.
+  Only templates you've created are returned. If you don't include a token in the authorization
+  header, you will receive an empty list
   """
   findTemplatesByShowId(showId: ID!): [Template!]!
   """
@@ -119,8 +119,8 @@ type Query {
   2. Matching show name (case sensitive) and season (case sensitive)
   3. Matching show name (case sensitive)
 
-  Only templates you've created are returned. If you don't pass auth to this method, it will an
-  error saying not found.
+  Only templates you've created are returned. If you don't include a token in the authorization
+  header, you will get a not found error, same as if the template was not found.
   """
   findTemplateByDetails(
     episodeId: ID

--- a/internal/graphql/resolvers/template.go
+++ b/internal/graphql/resolvers/template.go
@@ -16,7 +16,7 @@ import (
 
 func (r *Resolver) getTemplateByID(ctx context.Context, id *uuid.UUID) (*internal.Template, error) {
 	if id == nil {
-		return nil, nil
+		return nil, internal.NewNotFound("Template", "GetTemplateByID")
 	}
 	template, err := r.TemplateService.Get(ctx, internal.TemplatesFilter{
 		ID:             id,
@@ -31,7 +31,7 @@ func (r *Resolver) getTemplateByID(ctx context.Context, id *uuid.UUID) (*interna
 func (r *Resolver) getTemplateByEpisodeID(ctx context.Context, episodeID *uuid.UUID) (*internal.Template, error) {
 	auth, err := context.GetAuthClaims(ctx)
 	if err != nil {
-		return nil, &internal.Error{Code: internal.ENOTFOUND}
+		return nil, internal.NewNotFound("Template", "GetTemplateByEpisodeID")
 	}
 
 	template, err := r.TemplateService.Get(ctx, internal.TemplatesFilter{
@@ -130,14 +130,13 @@ func (r *queryResolver) FindTemplatesByShowID(ctx context.Context, showID *uuid.
 func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uuid.UUID, showName *string, season *string) (*internal.Template, error) {
 	auth, err := context.GetAuthClaims(ctx)
 	if err != nil {
-		return nil, &internal.Error{Code: internal.ENOTFOUND}
+		return nil, internal.NewNotFound("Template", "FindTemplateByDetails")
 	}
-
-	templates := []internal.Template{}
 
 	// 1. Matching source episodeId
 	if episodeID != nil {
-		templates, err := r.TemplateService.List(ctx, internal.TemplatesFilter{
+		templates := []internal.Template{}
+		templates, err = r.TemplateService.List(ctx, internal.TemplatesFilter{
 			SourceEpisodeID: episodeID,
 			CreatedByUserID: &auth.UserID,
 		})

--- a/internal/graphql/resolvers/template.go
+++ b/internal/graphql/resolvers/template.go
@@ -157,7 +157,7 @@ func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uu
 
 		// 2. Matching show name (case sensitive) and season (case sensitive)
 		if season != nil {
-			templates, err = r.TemplateService.List(ctx, internal.TemplatesFilter{
+			templates, err := r.TemplateService.List(ctx, internal.TemplatesFilter{
 				ShowID:          show.ID,
 				Season:          season,
 				Type:            lo.ToPtr(internal.TemplateTypeSeasons),
@@ -171,7 +171,7 @@ func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uu
 		}
 
 		// 3. Matching show name (case sensitive)
-		templates, err = r.TemplateService.List(ctx, internal.TemplatesFilter{
+		templates, err := r.TemplateService.List(ctx, internal.TemplatesFilter{
 			ShowID:          show.ID,
 			Type:            lo.ToPtr(internal.TemplateTypeShow),
 			CreatedByUserID: &auth.UserID,

--- a/internal/graphql/resolvers/template.go
+++ b/internal/graphql/resolvers/template.go
@@ -16,7 +16,7 @@ import (
 
 func (r *Resolver) getTemplateByID(ctx context.Context, id *uuid.UUID) (*internal.Template, error) {
 	if id == nil {
-		return nil, internal.NewNotFound("Template", "GetTemplateByID")
+		return nil, nil
 	}
 	template, err := r.TemplateService.Get(ctx, internal.TemplatesFilter{
 		ID:             id,

--- a/internal/graphql/resolvers/template.go
+++ b/internal/graphql/resolvers/template.go
@@ -29,8 +29,14 @@ func (r *Resolver) getTemplateByID(ctx context.Context, id *uuid.UUID) (*interna
 }
 
 func (r *Resolver) getTemplateByEpisodeID(ctx context.Context, episodeID *uuid.UUID) (*internal.Template, error) {
+	auth, err := context.GetAuthClaims(ctx)
+	if err != nil {
+		return nil, &internal.Error{Code: internal.ENOTFOUND}
+	}
+
 	template, err := r.TemplateService.Get(ctx, internal.TemplatesFilter{
 		SourceEpisodeID: episodeID,
+		CreatedByUserID: &auth.UserID,
 	})
 	if err != nil {
 		return nil, err
@@ -39,8 +45,14 @@ func (r *Resolver) getTemplateByEpisodeID(ctx context.Context, episodeID *uuid.U
 }
 
 func (r *Resolver) getTemplatesByShowID(ctx context.Context, showID *uuid.UUID) ([]*internal.Template, error) {
+	auth, err := context.GetAuthClaims(ctx)
+	if err != nil {
+		return []*internal.Template{}, nil
+	}
+
 	templates, err := r.TemplateService.List(ctx, internal.TemplatesFilter{
-		ShowID: showID,
+		ShowID:          showID,
+		CreatedByUserID: &auth.UserID,
 	})
 	if err != nil {
 		return nil, err
@@ -116,12 +128,18 @@ func (r *queryResolver) FindTemplatesByShowID(ctx context.Context, showID *uuid.
 }
 
 func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uuid.UUID, showName *string, season *string) (*internal.Template, error) {
+	auth, err := context.GetAuthClaims(ctx)
+	if err != nil {
+		return nil, &internal.Error{Code: internal.ENOTFOUND}
+	}
+
 	templates := []internal.Template{}
 
 	// 1. Matching source episodeId
 	if episodeID != nil {
 		templates, err := r.TemplateService.List(ctx, internal.TemplatesFilter{
 			SourceEpisodeID: episodeID,
+			CreatedByUserID: &auth.UserID,
 		})
 		if err != nil {
 			return nil, err
@@ -141,9 +159,10 @@ func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uu
 		// 2. Matching show name (case sensitive) and season (case sensitive)
 		if season != nil {
 			templates, err = r.TemplateService.List(ctx, internal.TemplatesFilter{
-				ShowID: show.ID,
-				Season: season,
-				Type:   lo.ToPtr(internal.TemplateTypeSeasons),
+				ShowID:          show.ID,
+				Season:          season,
+				Type:            lo.ToPtr(internal.TemplateTypeSeasons),
+				CreatedByUserID: &auth.UserID,
 			})
 			if err != nil {
 				return nil, err
@@ -154,8 +173,9 @@ func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uu
 
 		// 3. Matching show name (case sensitive)
 		templates, err = r.TemplateService.List(ctx, internal.TemplatesFilter{
-			ShowID: show.ID,
-			Type:   lo.ToPtr(internal.TemplateTypeShow),
+			ShowID:          show.ID,
+			Type:            lo.ToPtr(internal.TemplateTypeShow),
+			CreatedByUserID: &auth.UserID,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/graphql/server.generated.go
+++ b/internal/graphql/server.generated.go
@@ -3797,7 +3797,7 @@ type ExternalLink {
   Get a list of templates based on the ` + "`" + `Template.showId` + "`" + `
 
   Only templates you've created are returned. If you don't include a token in the authorization
-  header, you will receive an empty list
+  header, you will receive an empty list.
   """
   findTemplatesByShowId(showId: ID!): [Template!]!
   """

--- a/internal/graphql/server.generated.go
+++ b/internal/graphql/server.generated.go
@@ -3789,15 +3789,15 @@ type ExternalLink {
   """
   Get template info based on a ` + "`" + `Template.id` + "`" + `
 
-  Only templates you've created are returned. If you don't pass auth to this method, it will an
-  error saying not found.
+  Only templates you've created are returned. If you don't include a token in the authorization
+  header, you will get a not found error, same as if the template was not found.
   """
   findTemplate(templateId: ID!): Template!
   """
   Get a list of templates based on the ` + "`" + `Template.showId` + "`" + `
 
-  Only templates you've created are returned. If you don't pass auth to this method, it will an
-  error saying not found.
+  Only templates you've created are returned. If you don't include a token in the authorization
+  header, you will receive an empty list
   """
   findTemplatesByShowId(showId: ID!): [Template!]!
   """
@@ -3808,8 +3808,8 @@ type ExternalLink {
   2. Matching show name (case sensitive) and season (case sensitive)
   3. Matching show name (case sensitive)
 
-  Only templates you've created are returned. If you don't pass auth to this method, it will an
-  error saying not found.
+  Only templates you've created are returned. If you don't include a token in the authorization
+  header, you will get a not found error, same as if the template was not found.
   """
   findTemplateByDetails(
     episodeId: ID

--- a/internal/graphql/server.generated.go
+++ b/internal/graphql/server.generated.go
@@ -3786,9 +3786,19 @@ type ExternalLink {
   allTimestampTypes: [TimestampType!]!
 
   # Templates
-  "Get template info based on a ` + "`" + `Template.id` + "`" + `"
+  """
+  Get template info based on a ` + "`" + `Template.id` + "`" + `
+
+  Only templates you've created are returned. If you don't pass auth to this method, it will an
+  error saying not found.
+  """
   findTemplate(templateId: ID!): Template!
-  "Get a list of templates based on the ` + "`" + `Template.showId` + "`" + `"
+  """
+  Get a list of templates based on the ` + "`" + `Template.showId` + "`" + `
+
+  Only templates you've created are returned. If you don't pass auth to this method, it will an
+  error saying not found.
+  """
   findTemplatesByShowId(showId: ID!): [Template!]!
   """
   Find the most relevant template based on a few search criteria. If multiple templates are found,
@@ -3797,6 +3807,9 @@ type ExternalLink {
   1. Matching ` + "`" + `sourceEpisodeID` + "`" + `
   2. Matching show name (case sensitive) and season (case sensitive)
   3. Matching show name (case sensitive)
+
+  Only templates you've created are returned. If you don't pass auth to this method, it will an
+  error saying not found.
   """
   findTemplateByDetails(
     episodeId: ID

--- a/internal/models.go
+++ b/internal/models.go
@@ -103,6 +103,7 @@ type ShowsFilter struct {
 }
 
 type TemplatesFilter struct {
+	CreatedByUserID *uuid.UUID
 	Pagination      *Pagination
 	ID              *uuid.UUID
 	SourceEpisodeID *uuid.UUID

--- a/internal/postgres/template_repo.go
+++ b/internal/postgres/template_repo.go
@@ -33,6 +33,9 @@ func findTemplates(ctx context.Context, tx internal.Tx, filter internal.Template
 	if filter.ID != nil {
 		query.Where("id = ?", *filter.ID)
 	}
+	if filter.CreatedByUserID != nil {
+		query.Where("created_by_user_id = ?", *filter.CreatedByUserID)
+	}
 	if filter.Season != nil {
 		query.Where("? = ANY(seasons)", *filter.Season)
 	}


### PR DESCRIPTION
Instead of removing the feature altogether, we're gonna try out only returning the templates you created.

- [x] Make changes
- [x] Manual test

---

See https://discordapp.com/channels/750150856447623300/750150856447623303/1007471061622857778
This closes https://github.com/anime-skip/player/issues/266