### PR TITLE
fix: parse auth token on all requests when provided

### DIFF
--- a/api/queries.graphqls
+++ b/api/queries.graphqls
@@ -103,14 +103,14 @@ type Query {
   Only templates you've created are returned. If you don't include a token in the authorization
   header, you will get a not found error, same as if the template was not found.
   """
-  findTemplate(templateId: ID!): Template! @authenticated
+  findTemplate(templateId: ID!): Template!
   """
   Get a list of templates based on the `Template.showId`
 
   Only templates you've created are returned. If you don't include a token in the authorization
   header, you will receive an empty list.
   """
-  findTemplatesByShowId(showId: ID!): [Template!]! @authenticated
+  findTemplatesByShowId(showId: ID!): [Template!]!
   """
   Find the most relevant template based on a few search criteria. If multiple templates are found,
   their priority is like so:
@@ -126,7 +126,7 @@ type Query {
     episodeId: ID
     showName: String
     season: String
-  ): Template! @authenticated
+  ): Template!
 
   "List or search through the authenticated user's API clients"
   myApiClients(

--- a/internal/graphql/resolvers/template.go
+++ b/internal/graphql/resolvers/template.go
@@ -31,7 +31,7 @@ func (r *Resolver) getTemplateByID(ctx context.Context, id *uuid.UUID) (*interna
 func (r *Resolver) getTemplateByEpisodeID(ctx context.Context, episodeID *uuid.UUID) (*internal.Template, error) {
 	auth, err := context.GetAuthClaims(ctx)
 	if err != nil {
-		return nil, err
+		return nil, internal.NewNotFound("Template", "GetTemplateByEpisodeID")
 	}
 
 	template, err := r.TemplateService.Get(ctx, internal.TemplatesFilter{
@@ -47,7 +47,7 @@ func (r *Resolver) getTemplateByEpisodeID(ctx context.Context, episodeID *uuid.U
 func (r *Resolver) getTemplatesByShowID(ctx context.Context, showID *uuid.UUID) ([]*internal.Template, error) {
 	auth, err := context.GetAuthClaims(ctx)
 	if err != nil {
-		return nil, err
+		return []*internal.Template{}, nil
 	}
 
 	templates, err := r.TemplateService.List(ctx, internal.TemplatesFilter{
@@ -130,12 +130,13 @@ func (r *queryResolver) FindTemplatesByShowID(ctx context.Context, showID *uuid.
 func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uuid.UUID, showName *string, season *string) (*internal.Template, error) {
 	auth, err := context.GetAuthClaims(ctx)
 	if err != nil {
-		return nil, err
+		return nil, internal.NewNotFound("Template", "FindTemplateByDetails")
 	}
 
 	// 1. Matching source episodeId
 	if episodeID != nil {
-		templates, err := r.TemplateService.List(ctx, internal.TemplatesFilter{
+		templates := []internal.Template{}
+		templates, err = r.TemplateService.List(ctx, internal.TemplatesFilter{
 			SourceEpisodeID: episodeID,
 			CreatedByUserID: &auth.UserID,
 		})

--- a/internal/graphql/server.generated.go
+++ b/internal/graphql/server.generated.go
@@ -3792,14 +3792,14 @@ type ExternalLink {
   Only templates you've created are returned. If you don't include a token in the authorization
   header, you will get a not found error, same as if the template was not found.
   """
-  findTemplate(templateId: ID!): Template! @authenticated
+  findTemplate(templateId: ID!): Template!
   """
   Get a list of templates based on the ` + "`" + `Template.showId` + "`" + `
 
   Only templates you've created are returned. If you don't include a token in the authorization
   header, you will receive an empty list.
   """
-  findTemplatesByShowId(showId: ID!): [Template!]! @authenticated
+  findTemplatesByShowId(showId: ID!): [Template!]!
   """
   Find the most relevant template based on a few search criteria. If multiple templates are found,
   their priority is like so:
@@ -3815,7 +3815,7 @@ type ExternalLink {
     episodeId: ID
     showName: String
     season: String
-  ): Template! @authenticated
+  ): Template!
 
   "List or search through the authenticated user's API clients"
   myApiClients(
@@ -15102,28 +15102,8 @@ func (ec *executionContext) _Query_findTemplate(ctx context.Context, field graph
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Query().FindTemplate(rctx, fc.Args["templateId"].(*uuid.UUID))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.Authenticated == nil {
-				return nil, errors.New("directive authenticated is not implemented")
-			}
-			return ec.directives.Authenticated(ctx, nil, directive0)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*internal.Template); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *anime-skip.com/public-api/internal.Template`, tmp)
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().FindTemplate(rctx, fc.Args["templateId"].(*uuid.UUID))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -15215,28 +15195,8 @@ func (ec *executionContext) _Query_findTemplatesByShowId(ctx context.Context, fi
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Query().FindTemplatesByShowID(rctx, fc.Args["showId"].(*uuid.UUID))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.Authenticated == nil {
-				return nil, errors.New("directive authenticated is not implemented")
-			}
-			return ec.directives.Authenticated(ctx, nil, directive0)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.([]*internal.Template); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be []*anime-skip.com/public-api/internal.Template`, tmp)
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().FindTemplatesByShowID(rctx, fc.Args["showId"].(*uuid.UUID))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -15328,28 +15288,8 @@ func (ec *executionContext) _Query_findTemplateByDetails(ctx context.Context, fi
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Query().FindTemplateByDetails(rctx, fc.Args["episodeId"].(*uuid.UUID), fc.Args["showName"].(*string), fc.Args["season"].(*string))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.Authenticated == nil {
-				return nil, errors.New("directive authenticated is not implemented")
-			}
-			return ec.directives.Authenticated(ctx, nil, directive0)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*internal.Template); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *anime-skip.com/public-api/internal.Template`, tmp)
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().FindTemplateByDetails(rctx, fc.Args["episodeId"].(*uuid.UUID), fc.Args["showName"].(*string), fc.Args["season"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)


### PR DESCRIPTION
Reverts anime-skip/public-api#97

This does not work for nested queries :/

```graphql
findEpisode(...) {
  template {
    ...
  }
}
```