### PR TITLE
fix: `optionalAuthentication` for loading templates when not logged in

### DIFF
--- a/api/directives.graphqls
+++ b/api/directives.graphqls
@@ -1,8 +1,11 @@
-"Check if the user is signed in"
+"Check if the user is signed in."
 directive @authenticated on FIELD_DEFINITION
 
-"Checks if the user is signed in and has a given role"
+"If the user is signed in, use their details to customize the response, but don't throw an authentication error if a token is not passed."
+directive @optionalAuthenticated on FIELD_DEFINITION
+
+"Checks if the user is signed in and has a given role."
 directive @hasRole(role: Role!) on FIELD_DEFINITION
 
-"Checks if the user is signed in and is an admin of the show being operated on"
+"Checks if the user is signed in and is an admin of the show being operated on."
 directive @isShowAdmin on ARGUMENT_DEFINITION

--- a/api/models.graphqls
+++ b/api/models.graphqls
@@ -92,7 +92,7 @@ type Episode implements BaseModel {
   "The list of urls and services that the episode can be accessed from"
   urls: [EpisodeUrl!]!
   "If the episode is the source episode for a `Template`, this will resolve to that template"
-  template: Template @authenticated
+  template: Template @optionalAuthenticated
 }
 
 """
@@ -328,7 +328,7 @@ type Show implements BaseModel {
   "All the episodes that belong to the show"
   episodes: [Episode!]!
   "All the templates that belong to this show"
-  templates: [Template!]! @authenticated
+  templates: [Template!]! @optionalAuthenticated
   "Any links to external sites (just Anilist right now) for the show"
   externalLinks: [ExternalLink!]!
 
@@ -526,7 +526,7 @@ input InputTemplate {
 "The many to many object that links a timestamp to a template"
 type TemplateTimestamp {
   templateId: ID!
-  template: Template! @authenticated
+  template: Template! @optionalAuthenticated
   timestampId: ID!
   timestamp: Timestamp!
 }

--- a/api/queries.graphqls
+++ b/api/queries.graphqls
@@ -103,14 +103,14 @@ type Query {
   Only templates you've created are returned. If you don't include a token in the authorization
   header, you will get a not found error, same as if the template was not found.
   """
-  findTemplate(templateId: ID!): Template! @authenticated
+  findTemplate(templateId: ID!): Template! @optionalAuthenticated
   """
   Get a list of templates based on the `Template.showId`
 
   Only templates you've created are returned. If you don't include a token in the authorization
   header, you will receive an empty list.
   """
-  findTemplatesByShowId(showId: ID!): [Template!]! @authenticated
+  findTemplatesByShowId(showId: ID!): [Template!]! @optionalAuthenticated
   """
   Find the most relevant template based on a few search criteria. If multiple templates are found,
   their priority is like so:
@@ -126,7 +126,7 @@ type Query {
     episodeId: ID
     showName: String
     season: String
-  ): Template! @authenticated
+  ): Template! @optionalAuthenticated
 
   "List or search through the authenticated user's API clients"
   myApiClients(

--- a/internal/context/auth_claims.go
+++ b/internal/context/auth_claims.go
@@ -17,7 +17,7 @@ func GetAuthClaims(ctx context.Context) (internal.AuthClaims, error) {
 	if !ok {
 		return internal.AuthClaims{}, &internal.Error{
 			Code:    internal.EINTERNAL,
-			Message: "AuthClaims is not set yet, does this query/mutation use the @authenticated directive?",
+			Message: "AuthClaims is not set yet, does this query/mutation use the @authenticated or @optionalAuthenticated directive?",
 			Op:      "GetAuthClaims",
 		}
 	}

--- a/internal/graphql/directives/optional_authenticated.go
+++ b/internal/graphql/directives/optional_authenticated.go
@@ -1,0 +1,17 @@
+package directives
+
+import (
+	ctx "context"
+
+	"anime-skip.com/public-api/internal/context"
+	"github.com/99designs/gqlgen/graphql"
+)
+
+func OptionalAuthenticated(ctx ctx.Context, obj any, next graphql.Resolver) (any, error) {
+	token := context.GetAuthToken(ctx)
+	if token == "" {
+		return next(ctx)
+	} else {
+		return Authenticated(ctx, obj, next)
+	}
+}

--- a/internal/graphql/handler/handler.go
+++ b/internal/graphql/handler/handler.go
@@ -25,9 +25,10 @@ func NewGraphqlHandler(db internal.Database, services internal.Services, rateLim
 			DB:       db,
 		},
 		Directives: graphql.DirectiveRoot{
-			Authenticated: directives.Authenticated,
-			HasRole:       directives.HasRole,
-			IsShowAdmin:   directives.IsShowAdmin,
+			Authenticated:         directives.Authenticated,
+			OptionalAuthenticated: directives.OptionalAuthenticated,
+			HasRole:               directives.HasRole,
+			IsShowAdmin:           directives.IsShowAdmin,
 		},
 	}
 	srv := handler.New(graphql.NewExecutableSchema(config))


### PR DESCRIPTION
Requests would fail if including templates when looking up episode URLs if not logged in, instead of just returning null for the template. So I added a new auth directive that allows either auth or no auth, and sets the auth claims when available.