### PR TITLE
fix: sort templates newest first

### DIFF
--- a/internal/graphql/resolvers/template.go
+++ b/internal/graphql/resolvers/template.go
@@ -29,6 +29,7 @@ func (r *Resolver) getTemplateByID(ctx context.Context, id *uuid.UUID) (*interna
 	template, err := r.TemplateService.Get(ctx, internal.TemplatesFilter{
 		ID:             id,
 		IncludeDeleted: true,
+		Sort:           &internal.SortBy{Column: "created_at", Direction: "DESC"},
 	})
 	if err != nil {
 		return nil, err
@@ -45,6 +46,7 @@ func (r *Resolver) getTemplateByEpisodeID(ctx context.Context, episodeID *uuid.U
 	template, err := r.TemplateService.Get(ctx, internal.TemplatesFilter{
 		SourceEpisodeID: episodeID,
 		CreatedByUserID: authUserID,
+		Sort:            &internal.SortBy{Column: "created_at", Direction: "DESC"},
 	})
 	if err != nil {
 		return nil, err
@@ -61,6 +63,7 @@ func (r *Resolver) getTemplatesByShowID(ctx context.Context, showID *uuid.UUID) 
 	templates, err := r.TemplateService.List(ctx, internal.TemplatesFilter{
 		ShowID:          showID,
 		CreatedByUserID: authUserID,
+		Sort:            &internal.SortBy{Column: "created_at", Direction: "DESC"},
 	})
 	if err != nil {
 		return nil, err
@@ -140,12 +143,14 @@ func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uu
 	if authUserID == nil {
 		return nil, internal.NewNotFound("Template", "GetTemplateByEpisodeID")
 	}
+	sort := &internal.SortBy{Column: "created_at", Direction: "DESC"}
 
 	// 1. Matching source episodeId
 	if episodeID != nil {
 		templates, err := r.TemplateService.List(ctx, internal.TemplatesFilter{
 			SourceEpisodeID: episodeID,
 			CreatedByUserID: authUserID,
+			Sort:            sort,
 		})
 		if err != nil {
 			return nil, err
@@ -169,6 +174,7 @@ func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uu
 				Season:          season,
 				Type:            lo.ToPtr(internal.TemplateTypeSeasons),
 				CreatedByUserID: authUserID,
+				Sort:            sort,
 			})
 			if err != nil {
 				return nil, err
@@ -182,6 +188,7 @@ func (r *queryResolver) FindTemplateByDetails(ctx context.Context, episodeID *uu
 			ShowID:          show.ID,
 			Type:            lo.ToPtr(internal.TemplateTypeShow),
 			CreatedByUserID: authUserID,
+			Sort:            sort,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/models.go
+++ b/internal/models.go
@@ -35,6 +35,11 @@ type Pagination struct {
 	Limit  int
 }
 
+type SortBy struct {
+	Column    string
+	Direction string
+}
+
 type APIClientsFilter struct {
 	Pagination     *Pagination
 	ID             *string
@@ -111,6 +116,7 @@ type TemplatesFilter struct {
 	Season          *string
 	Type            *TemplateType
 	IncludeDeleted  bool
+	Sort            *SortBy
 }
 
 type TemplateTimestampsFilter struct {

--- a/internal/postgres/template_repo.go
+++ b/internal/postgres/template_repo.go
@@ -55,7 +55,9 @@ func findTemplates(ctx context.Context, tx internal.Tx, filter internal.Template
 	if filter.Pagination != nil {
 		query.Paginate(*filter.Pagination)
 	}
-	query.OrderBy("type", "ASC")
+	if filter.Sort != nil {
+		query.OrderBy(filter.Sort.Column, filter.Sort.Direction)
+	}
 
 	sql, args := query.ToSQL()
 	rows, err := tx.QueryContext(ctx, sql, args...)


### PR DESCRIPTION
That way the latest template is returned instead of the oldest, which might make the user think the wrong template is being used.

This closes https://github.com/anime-skip/player/issues/266