### PR TITLE
feat: add `counts` query for getting latest counts of all major models

### DIFF
--- a/api/models.graphqls
+++ b/api/models.graphqls
@@ -578,3 +578,13 @@ type ExternalLink {
   service: String!
   serviceId: String
 }
+
+type TotalCounts {
+  episodes: Int!
+  episodeUrls: Int!
+  shows: Int!
+  timestamps: Int!
+  timestampTypes: Int!
+  users: Int!
+  templates: Int!
+}

--- a/api/queries.graphqls
+++ b/api/queries.graphqls
@@ -138,4 +138,6 @@ type Query {
 
   "Find an API Client that you created based on it's ID. This will not return other users' clients"
   findApiClient(id: String!): ApiClient! @authenticated
+
+  counts: TotalCounts
 }

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -169,3 +169,19 @@ models:
         resolver: true
       serviceId:
         resolver: true
+  TotalCounts:
+    fields:
+      episodes:
+        resolver: true
+      episodeUrls:
+        resolver: true
+      shows:
+        resolver: true
+      timestamps:
+        resolver: true
+      timestampTypes:
+        resolver: true
+      users:
+        resolver: true
+      templates:
+        resolver: true

--- a/internal/graphql/resolvers/counts.go
+++ b/internal/graphql/resolvers/counts.go
@@ -1,0 +1,54 @@
+package resolvers
+
+import (
+	"anime-skip.com/public-api/internal"
+	"anime-skip.com/public-api/internal/context"
+)
+
+// Helpers
+
+// Mutations
+
+// Queries
+
+// Counts implements graphql.QueryResolver
+func (*queryResolver) Counts(ctx context.Context) (*internal.TotalCounts, error) {
+	return &internal.TotalCounts{}, nil
+}
+
+// Fields
+
+// EpisodeUrls implements graphql.TotalCountsResolver
+func (r *totalCountsResolver) EpisodeUrls(ctx context.Context, obj *internal.TotalCounts) (int, error) {
+	return r.EpisodeURLService.Count(ctx)
+}
+
+// Episodes implements graphql.TotalCountsResolver
+func (r *totalCountsResolver) Episodes(ctx context.Context, obj *internal.TotalCounts) (int, error) {
+	return r.EpisodeService.Count(ctx)
+}
+
+// Shows implements graphql.TotalCountsResolver
+func (r *totalCountsResolver) Shows(ctx context.Context, obj *internal.TotalCounts) (int, error) {
+	return r.ShowService.Count(ctx)
+}
+
+// Templates implements graphql.TotalCountsResolver
+func (r *totalCountsResolver) Templates(ctx context.Context, obj *internal.TotalCounts) (int, error) {
+	return r.TemplateService.Count(ctx)
+}
+
+// TimestampTypes implements graphql.TotalCountsResolver
+func (r *totalCountsResolver) TimestampTypes(ctx context.Context, obj *internal.TotalCounts) (int, error) {
+	return r.TimestampTypeService.Count(ctx)
+}
+
+// Timestmaps implements graphql.TotalCountsResolver
+func (r *totalCountsResolver) Timestamps(ctx context.Context, obj *internal.TotalCounts) (int, error) {
+	return r.TimestampService.Count(ctx)
+}
+
+// Users implements graphql.TotalCountsResolver
+func (r *totalCountsResolver) Users(ctx context.Context, obj *internal.TotalCounts) (int, error) {
+	return r.UserService.Count(ctx)
+}

--- a/internal/graphql/resolvers/interfaces.go
+++ b/internal/graphql/resolvers/interfaces.go
@@ -62,6 +62,9 @@ func (r *Resolver) Timestamp() graphql.TimestampResolver { return &timestampReso
 // TimestampType returns graphql.TimestampTypeResolver implementation.
 func (r *Resolver) TimestampType() graphql.TimestampTypeResolver { return &timestampTypeResolver{r} }
 
+// TimestampType returns graphql.TimestampTypeResolver implementation.
+func (r *Resolver) TotalCounts() graphql.TotalCountsResolver { return &totalCountsResolver{r} }
+
 // User returns graphql.UserResolver implementation.
 func (r *Resolver) User() graphql.UserResolver { return &userResolver{r} }
 
@@ -80,4 +83,5 @@ type templateTimestampResolver struct{ *Resolver }
 type thirdPartyTimestampResolver struct{ *Resolver }
 type timestampResolver struct{ *Resolver }
 type timestampTypeResolver struct{ *Resolver }
+type totalCountsResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }

--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -55,6 +55,7 @@ type EpisodeService interface {
 	Create(ctx context.Context, newEpisode Episode, createdBy uuid.UUID) (Episode, error)
 	Update(ctx context.Context, newEpisode Episode, updatedBy uuid.UUID) (Episode, error)
 	Delete(ctx context.Context, id uuid.UUID, deletedBy uuid.UUID) (Episode, error)
+	Count(ctx context.Context) (int, error)
 }
 
 type EpisodeURLService interface {
@@ -63,6 +64,7 @@ type EpisodeURLService interface {
 	Create(ctx context.Context, newEpisodeURL EpisodeURL, createdBy uuid.UUID) (EpisodeURL, error)
 	Update(ctx context.Context, newEpisodeURL EpisodeURL, updatedBy uuid.UUID) (EpisodeURL, error)
 	Delete(ctx context.Context, url string) (EpisodeURL, error)
+	Count(ctx context.Context) (int, error)
 }
 
 type ExternalLinkService interface {
@@ -92,6 +94,7 @@ type ShowService interface {
 	Create(ctx context.Context, newShow Show, createdBy uuid.UUID) (Show, error)
 	Update(ctx context.Context, newShow Show, updatedBy uuid.UUID) (Show, error)
 	Delete(ctx context.Context, id uuid.UUID, deletedBy uuid.UUID) (Show, error)
+	Count(ctx context.Context) (int, error)
 }
 
 type TemplateService interface {
@@ -100,6 +103,7 @@ type TemplateService interface {
 	Create(ctx context.Context, newTemplate Template, createdBy uuid.UUID) (Template, error)
 	Update(ctx context.Context, newTemplate Template, updatedBy uuid.UUID) (Template, error)
 	Delete(ctx context.Context, id uuid.UUID, deletedBy uuid.UUID) (Template, error)
+	Count(ctx context.Context) (int, error)
 }
 
 type TemplateTimestampService interface {
@@ -116,6 +120,7 @@ type TimestampService interface {
 	UpdateAll(ctx context.Context, create []Timestamp, update []Timestamp, delete []Timestamp, updatedBy uuid.UUID) (created []Timestamp, updated []Timestamp, deleted []Timestamp, err error)
 	Update(ctx context.Context, newTimestamp Timestamp, updatedBy uuid.UUID) (Timestamp, error)
 	Delete(ctx context.Context, id uuid.UUID, deletedBy uuid.UUID) (Timestamp, error)
+	Count(ctx context.Context) (int, error)
 }
 
 type TimestampTypeService interface {
@@ -124,6 +129,7 @@ type TimestampTypeService interface {
 	Create(ctx context.Context, newTimestampType TimestampType, createdBy uuid.UUID) (TimestampType, error)
 	Update(ctx context.Context, newTimestampType TimestampType, updatedBy uuid.UUID) (TimestampType, error)
 	Delete(ctx context.Context, id uuid.UUID, deletedBy uuid.UUID) (TimestampType, error)
+	Count(ctx context.Context) (int, error)
 }
 
 type UserService interface {
@@ -131,6 +137,7 @@ type UserService interface {
 	List(ctx context.Context, filter UsersFilter) ([]FullUser, error)
 	CreateAccount(ctx context.Context, newUser FullUser) (FullUser, error)
 	Update(ctx context.Context, newUser FullUser) (FullUser, error)
+	Count(ctx context.Context) (int, error)
 }
 
 type ThirdPartyService interface {

--- a/internal/models.generated.go
+++ b/internal/models.generated.go
@@ -508,6 +508,16 @@ type TimestampType struct {
 
 func (TimestampType) IsBaseModel() {}
 
+type TotalCounts struct {
+	Episodes       int `json:"episodes"`
+	EpisodeUrls    int `json:"episodeUrls"`
+	Shows          int `json:"shows"`
+	Timestamps     int `json:"timestamps"`
+	TimestampTypes int `json:"timestampTypes"`
+	Users          int `json:"users"`
+	Templates      int `json:"templates"`
+}
+
 type UpdatedTimestamps struct {
 	Created []*Timestamp `json:"created"`
 	Updated []*Timestamp `json:"updated"`

--- a/internal/postgres/episode_service.go
+++ b/internal/postgres/episode_service.go
@@ -56,3 +56,9 @@ func (s *episodeService) Delete(ctx context.Context, id uuid.UUID, deletedBy uui
 		return deleteCascadeEpisode(ctx, tx, existing, deletedBy)
 	})
 }
+
+func (s *episodeService) Count(ctx context.Context) (int, error) {
+	return inTx(ctx, s.db, false, 0, func(tx internal.Tx) (int, error) {
+		return count(ctx, tx, "SELECT COUNT(*) FROM episodes WHERE deleted_at IS NULL")
+	})
+}

--- a/internal/postgres/episode_url_service.go
+++ b/internal/postgres/episode_url_service.go
@@ -50,3 +50,9 @@ func (s *episodeURLService) Delete(ctx context.Context, url string) (internal.Ep
 		return deleteCascadeEpisodeURL(ctx, tx, existing)
 	})
 }
+
+func (s *episodeURLService) Count(ctx context.Context) (int, error) {
+	return inTx(ctx, s.db, false, 0, func(tx internal.Tx) (int, error) {
+		return count(ctx, tx, "SELECT COUNT(*) FROM episode_urls")
+	})
+}

--- a/internal/postgres/show_service.go
+++ b/internal/postgres/show_service.go
@@ -82,3 +82,9 @@ func (s *showService) Delete(ctx context.Context, id uuid.UUID, deletedBy uuid.U
 		return deleteCascadeShow(ctx, tx, existing, deletedBy)
 	})
 }
+
+func (s *showService) Count(ctx context.Context) (int, error) {
+	return inTx(ctx, s.db, false, 0, func(tx internal.Tx) (int, error) {
+		return count(ctx, tx, "SELECT COUNT(*) FROM shows WHERE deleted_at IS NULL")
+	})
+}

--- a/internal/postgres/template_service.go
+++ b/internal/postgres/template_service.go
@@ -50,3 +50,9 @@ func (s *templateService) Delete(ctx context.Context, id uuid.UUID, deletedBy uu
 		return deleteCascadeTemplate(ctx, tx, existing, deletedBy)
 	})
 }
+
+func (s *templateService) Count(ctx context.Context) (int, error) {
+	return inTx(ctx, s.db, false, 0, func(tx internal.Tx) (int, error) {
+		return count(ctx, tx, "SELECT COUNT(*) FROM templates WHERE deleted_at IS NULL")
+	})
+}

--- a/internal/postgres/template_timestamp_service.go
+++ b/internal/postgres/template_timestamp_service.go
@@ -44,3 +44,9 @@ func (s *templateTimestampService) Delete(ctx context.Context, templateTimestamp
 		return deleteCascadeTemplateTimestamp(ctx, tx, existing)
 	})
 }
+
+func (s *timestampTypeService) Count(ctx context.Context) (int, error) {
+	return inTx(ctx, s.db, false, 0, func(tx internal.Tx) (int, error) {
+		return count(ctx, tx, "SELECT COUNT(*) FROM timestamp_types WHERE deleted_at IS NULL")
+	})
+}

--- a/internal/postgres/template_timestamp_service.go
+++ b/internal/postgres/template_timestamp_service.go
@@ -44,9 +44,3 @@ func (s *templateTimestampService) Delete(ctx context.Context, templateTimestamp
 		return deleteCascadeTemplateTimestamp(ctx, tx, existing)
 	})
 }
-
-func (s *timestampTypeService) Count(ctx context.Context) (int, error) {
-	return inTx(ctx, s.db, false, 0, func(tx internal.Tx) (int, error) {
-		return count(ctx, tx, "SELECT COUNT(*) FROM timestamp_types WHERE deleted_at IS NULL")
-	})
-}

--- a/internal/postgres/timestamp_service.go
+++ b/internal/postgres/timestamp_service.go
@@ -79,3 +79,9 @@ func (s *timestampService) Delete(ctx context.Context, id uuid.UUID, deletedBy u
 		return deleteCascadeTimestamp(ctx, tx, existing, deletedBy)
 	})
 }
+
+func (s *timestampService) Count(ctx context.Context) (int, error) {
+	return inTx(ctx, s.db, false, 0, func(tx internal.Tx) (int, error) {
+		return count(ctx, tx, "SELECT COUNT(*) FROM timestamps WHERE deleted_at IS NULL")
+	})
+}

--- a/internal/postgres/timestamp_type_service.go
+++ b/internal/postgres/timestamp_type_service.go
@@ -50,3 +50,9 @@ func (s *timestampTypeService) Delete(ctx context.Context, id uuid.UUID, deleted
 		return deleteCascadeTimestampType(ctx, tx, existing, deletedBy)
 	})
 }
+
+func (s *timestampTypeService) Count(ctx context.Context) (int, error) {
+	return inTx(ctx, s.db, false, 0, func(tx internal.Tx) (int, error) {
+		return count(ctx, tx, "SELECT COUNT(*) FROM timestamp_types WHERE deleted_at IS NULL")
+	})
+}

--- a/internal/postgres/user_service.go
+++ b/internal/postgres/user_service.go
@@ -46,3 +46,9 @@ func (s *userService) Update(ctx context.Context, newUser internal.FullUser) (in
 		return updateUser(ctx, tx, newUser)
 	})
 }
+
+func (s *userService) Count(ctx context.Context) (int, error) {
+	return inTx(ctx, s.db, false, 0, func(tx internal.Tx) (int, error) {
+		return count(ctx, tx, "SELECT COUNT(*) FROM users")
+	})
+}


### PR DESCRIPTION
```graphql
{
  counts {
    episodes
    episodeUrls
    timestamps
    timestampTypes
    templates
    users
  }
}

```
```json
{
  "data": {
    "counts": {
      "episodes": 4482,
      "episodeUrls": 5178,
      "timestamps": 23807,
      "timestampTypes": 15,
      "templates": 164,
      "users": 1908
    }
  }
}
```