### PR TITLE
fix: use current user details, not from token

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,9 +37,11 @@ func main() {
 	pgEpisodeURLService := postgres.NewEpisodeURLService(pg)
 	pgShowAdminService := postgres.NewShowAdminService(pg)
 	pgTemplateService := postgres.NewTemplateService(pg)
+	pgUserService := postgres.NewUserService(pg)
 
 	jwtAuthService := jwt.NewJWTAuthService(
 		config.JWTSecret(),
+		pgUserService,
 	)
 	httpEmailService := http.NewAnimeSkipEmailService(
 		config.EmailServiceHost(),
@@ -76,7 +78,7 @@ func main() {
 		TemplateTimestampService: postgres.NewTemplateTimestampService(pg),
 		TimestampService:         postgres.NewTimestampService(pg),
 		TimestampTypeService:     postgres.NewTimestampTypeService(pg),
-		UserService:              postgres.NewUserService(pg),
+		UserService:              pgUserService,
 		UserReportService:        postgres.NewUserReportService(pg, discord),
 		ThirdPartyService: utils.NewAggregateThirdPartyService([]internal.ThirdPartyService{
 			postgres.NewThirdPartyService(pg),

--- a/internal/graphql/directives/authenticated.go
+++ b/internal/graphql/directives/authenticated.go
@@ -22,7 +22,7 @@ func authenticate(ctx ctx.Context) (ctx.Context, error) {
 			Op:      "authenticate",
 		}
 	}
-	details, err := services.AuthService.ValidateAccessToken(token)
+	details, err := services.AuthService.ValidateAccessToken(ctx, token)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/graphql/directives/has_role.go
+++ b/internal/graphql/directives/has_role.go
@@ -40,7 +40,7 @@ func HasRole(ctx context1.Context, obj any, next graphql.Resolver, requiredRole 
 	if !hasRole {
 		return nil, &internal.Error{
 			Code:    internal.EINVALID,
-			Message: fmt.Sprintf("Forbidden - you don't have the required role to perform this action (required: %s, has: %d)", requiredRole, auth.Role),
+			Message: fmt.Sprintf("Forbidden - you don't have the required role to perform this action (required: %s, has: %s)", requiredRole, auth.Role),
 			Op:      "hasRole",
 		}
 	}

--- a/internal/graphql/directives/has_role.go
+++ b/internal/graphql/directives/has_role.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	DEV_ROLES      = []int64{internal.ROLE_DEV}
-	ADMIN_ROLES    = []int64{internal.ROLE_DEV, internal.ROLE_ADMIN}
-	REVIEWER_ROLES = []int64{internal.ROLE_DEV, internal.ROLE_ADMIN, internal.ROLE_REVIEWER}
+	DEV_ROLES      = []internal.Role{internal.RoleDev}
+	ADMIN_ROLES    = []internal.Role{internal.RoleDev, internal.RoleAdmin}
+	REVIEWER_ROLES = []internal.Role{internal.RoleDev, internal.RoleAdmin, internal.RoleReviewer}
 )
 
 func HasRole(ctx context1.Context, obj any, next graphql.Resolver, requiredRole internal.Role) (res any, err error) {

--- a/internal/graphql/directives/is_show_admin.go
+++ b/internal/graphql/directives/is_show_admin.go
@@ -134,7 +134,7 @@ func IsShowAdmin(ctx context.Context, params any, next graphql2.Resolver) (any, 
 	if err != nil {
 		return nil, err
 	}
-	if auth.Role == internal.ROLE_ADMIN || auth.Role == internal.ROLE_DEV {
+	if auth.Role == internal.RoleAdmin || auth.Role == internal.RoleDev {
 		log.V("@isShowAdmin - elevated role")
 		return next(ctx)
 	}

--- a/internal/graphql/resolvers/account.go
+++ b/internal/graphql/resolvers/account.go
@@ -234,7 +234,7 @@ func (r *mutationResolver) ResendVerificationEmail(ctx context.Context, recaptch
 }
 
 func (r *mutationResolver) VerifyEmailAddress(ctx context.Context, validationToken string) (*internal.Account, error) {
-	claims, err := r.AuthService.ValidateVerifyEmailToken(validationToken)
+	claims, err := r.AuthService.ValidateVerifyEmailToken(ctx, validationToken)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +298,7 @@ func (r *mutationResolver) ResetPassword(ctx context.Context, passwordResetToken
 		}
 	}
 
-	claims, err := r.AuthService.ValidateResetPasswordToken(passwordResetToken)
+	claims, err := r.AuthService.ValidateResetPasswordToken(ctx, passwordResetToken)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ func (r *queryResolver) Login(ctx context.Context, usernameOrEmail string, passw
 }
 
 func (r *queryResolver) LoginRefresh(ctx context.Context, refreshToken string) (*internal.LoginData, error) {
-	claims, err := r.AuthService.ValidateRefreshToken(refreshToken)
+	claims, err := r.AuthService.ValidateRefreshToken(ctx, refreshToken)
 	if err != nil {
 		return nil, &internal.Error{
 			Code:    internal.EINVALID,

--- a/internal/graphql/resolvers/api_client.go
+++ b/internal/graphql/resolvers/api_client.go
@@ -34,7 +34,7 @@ func (r *mutationResolver) UpdateAPIClient(ctx context.Context, id string, chang
 	if err != nil {
 		return nil, err
 	}
-	isAdmin := auth.Role == internal.ROLE_ADMIN || auth.Role == internal.ROLE_DEV
+	isAdmin := auth.Role == internal.RoleAdmin || auth.Role == internal.RoleDev
 	if _, ok := changes["rateLimitRpm"]; ok && !isAdmin {
 		return nil, &internal.Error{
 			Code:    internal.EINVALID,

--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -25,14 +25,14 @@ type APIClientService interface {
 }
 
 type AuthClaims struct {
-	Role   int64
+	Role   Role
 	UserID uuid.UUID
 }
 type AuthService interface {
-	ValidateAccessToken(token string) (AuthClaims, error)
-	ValidateRefreshToken(token string) (AuthClaims, error)
-	ValidateVerifyEmailToken(token string) (AuthClaims, error)
-	ValidateResetPasswordToken(token string) (AuthClaims, error)
+	ValidateAccessToken(ctx context.Context, token string) (AuthClaims, error)
+	ValidateRefreshToken(ctx context.Context, token string) (AuthClaims, error)
+	ValidateVerifyEmailToken(ctx context.Context, token string) (AuthClaims, error)
+	ValidateResetPasswordToken(ctx context.Context, token string) (AuthClaims, error)
 	ValidatePassword(inputPasswordHash, knownPasswordHash string) error
 	CreateAccessToken(user FullUser) (string, error)
 	CreateRefreshToken(user FullUser) (string, error)

--- a/internal/jwt/auth_service.go
+++ b/internal/jwt/auth_service.go
@@ -138,7 +138,6 @@ func (s *jwtAuthService) mapAuthClaims(ctx context.Context, claims jwt.MapClaims
 		ID: &userID,
 	})
 	if err != nil {
-		log.W("User ID in token not found (%v)", claims["userId"])
 		return internal.AuthClaims{}, err
 	}
 	return internal.AuthClaims{

--- a/internal/jwt/auth_service.go
+++ b/internal/jwt/auth_service.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -15,7 +16,8 @@ import (
 var day time.Duration = 24 * time.Hour
 
 type jwtAuthService struct {
-	secret []byte
+	secret      []byte
+	userService internal.UserService
 }
 
 // TODO: simplify audiences, switch to including permissions in the token instead
@@ -36,10 +38,11 @@ var TIMEOUT_RESET_PASSWORD_TOKEN = 10 * time.Minute
 // TODO: Change to api.anime-skip.com
 const ISSUER = "anime-skip.com"
 
-func NewJWTAuthService(secret string) internal.AuthService {
+func NewJWTAuthService(secret string, userService internal.UserService) internal.AuthService {
 	log.D("Using Custom JWT Authentication...")
 	return &jwtAuthService{
-		secret: []byte(secret),
+		secret:      []byte(secret),
+		userService: userService,
 	}
 }
 
@@ -126,48 +129,54 @@ func (s *jwtAuthService) validateToken(name string, token string, audience strin
 	return payload, nil
 }
 
-func (s *jwtAuthService) mapAuthClaims(claims jwt.MapClaims) (internal.AuthClaims, error) {
-	role := int64(claims["role"].(float64))
+func (s *jwtAuthService) mapAuthClaims(ctx context.Context, claims jwt.MapClaims) (internal.AuthClaims, error) {
 	userID, err := uuid.FromString(claims["userId"].(string))
 	if err != nil {
 		return internal.AuthClaims{}, err
 	}
+	user, err := s.userService.Get(ctx, internal.UsersFilter{
+		ID: &userID,
+	})
+	if err != nil {
+		log.W("User ID in token not found (%v)", claims["userId"])
+		return internal.AuthClaims{}, err
+	}
 	return internal.AuthClaims{
-		Role:   role,
-		UserID: userID,
+		Role:   user.Role,
+		UserID: user.ID,
 	}, nil
 }
 
-func (s *jwtAuthService) ValidateAccessToken(token string) (internal.AuthClaims, error) {
+func (s *jwtAuthService) ValidateAccessToken(ctx context.Context, token string) (internal.AuthClaims, error) {
 	claims, err := s.validateToken("Access", token, AUD_ACCESS_TOKEN)
 	if err != nil {
 		return internal.AuthClaims{}, err
 	}
-	return s.mapAuthClaims(claims)
+	return s.mapAuthClaims(ctx, claims)
 }
 
-func (s *jwtAuthService) ValidateRefreshToken(token string) (internal.AuthClaims, error) {
+func (s *jwtAuthService) ValidateRefreshToken(ctx context.Context, token string) (internal.AuthClaims, error) {
 	claims, err := s.validateToken("Refresh", token, AUD_REFRESH_TOKEN)
 	if err != nil {
 		return internal.AuthClaims{}, err
 	}
-	return s.mapAuthClaims(claims)
+	return s.mapAuthClaims(ctx, claims)
 }
 
-func (s *jwtAuthService) ValidateVerifyEmailToken(token string) (internal.AuthClaims, error) {
+func (s *jwtAuthService) ValidateVerifyEmailToken(ctx context.Context, token string) (internal.AuthClaims, error) {
 	claims, err := s.validateToken("Email", token, AUD_VERIFY_EMAIL_TOKEN)
 	if err != nil {
 		return internal.AuthClaims{}, err
 	}
-	return s.mapAuthClaims(claims)
+	return s.mapAuthClaims(ctx, claims)
 }
 
-func (s *jwtAuthService) ValidateResetPasswordToken(token string) (internal.AuthClaims, error) {
+func (s *jwtAuthService) ValidateResetPasswordToken(ctx context.Context, token string) (internal.AuthClaims, error) {
 	claims, err := s.validateToken("Password reset", token, AUD_RESET_PASSWORD_TOKEN)
 	if err != nil {
 		return internal.AuthClaims{}, err
 	}
-	return s.mapAuthClaims(claims)
+	return s.mapAuthClaims(ctx, claims)
 }
 
 func (s *jwtAuthService) ValidatePassword(inputPassword, hashedPassword string) error {


### PR DESCRIPTION
If your role changes, you shouldn't have to re-login, nor should you be able to use a token with an elevated role after being demoted. So we should load the role from the database instead of relying on the value from the token.