### PR TITLE
feat: query an `Episode`'s `userReports`

### DIFF
--- a/api/models.graphqls
+++ b/api/models.graphqls
@@ -93,6 +93,12 @@ type Episode implements BaseModel {
   urls: [EpisodeUrl!]!
   "If the episode is the source episode for a `Template`, this will resolve to that template"
   template: Template @optionalAuthenticated
+  """
+  List the user reports for the episode. Requires the REVIEWER role.
+
+  > `@hasRole(role: REVIEWER)` - The user must have the `REVIEWER` role to query this property.
+  """
+  userReports(resolved: Boolean): [UserReport!]! @hasRole(role: REVIEWER)
 }
 
 """

--- a/api/queries.graphqls
+++ b/api/queries.graphqls
@@ -151,6 +151,6 @@ type Query {
     sort: String = "DESC"
   ): [UserReport!]! @hasRole(role: REVIEWER)
 
-  "Get a single user report, even if it's been resolved/deleted."
+  "Get a single user report, even if it's been resolved/deleted. Requires the "
   findUserReport(id: ID!): UserReport! @hasRole(role: REVIEWER)
 }

--- a/api/queries.graphqls
+++ b/api/queries.graphqls
@@ -151,6 +151,6 @@ type Query {
     sort: String = "DESC"
   ): [UserReport!]! @hasRole(role: REVIEWER)
 
-  "Get a single user report, even if it's been resolved/deleted. Requires the "
+  "Get a single user report, even if it's been resolved/deleted."
   findUserReport(id: ID!): UserReport! @hasRole(role: REVIEWER)
 }

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -35,6 +35,8 @@ models:
         resolver: true
       template:
         resolver: true
+      userReports:
+        resolver: true
   EpisodeUrl:
     fields:
       createdBy:

--- a/internal/graphql/resolvers/episode.go
+++ b/internal/graphql/resolvers/episode.go
@@ -177,3 +177,11 @@ func (r *episodeResolver) Template(ctx context.Context, obj *internal.Episode) (
 	}
 	return template, err
 }
+
+// UserReports implements graphql.EpisodeResolver
+func (r *episodeResolver) UserReports(ctx context.Context, obj *internal.Episode, resolved *bool) ([]*internal.UserReport, error) {
+	return r.findUserReports(ctx, internal.UserReportsFilter{
+		Resolved:  resolved,
+		EpisodeID: obj.ID,
+	})
+}

--- a/internal/graphql/resolvers/user_report.go
+++ b/internal/graphql/resolvers/user_report.go
@@ -9,6 +9,16 @@ import (
 	"github.com/samber/lo"
 )
 
+// Helpers
+
+func (r *Resolver) findUserReports(ctx context.Context, filter internal.UserReportsFilter) ([]*internal.UserReport, error) {
+	reports, err := r.UserReportService.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	return lo.ToSlicePtr(reports), nil
+}
+
 // Mutations
 
 // CreateUserReport implements graphql.MutationResolver
@@ -71,19 +81,14 @@ func (r *queryResolver) FindUserReport(ctx context.Context, id *uuid.UUID) (*int
 
 // FindUserReports implements graphql.QueryResolver
 func (r *queryResolver) FindUserReports(ctx context.Context, resolved *bool, offset *int, limit *int, sort *string) ([]*internal.UserReport, error) {
-	filter := internal.UserReportsFilter{
+	return r.findUserReports(ctx, internal.UserReportsFilter{
 		Pagination: &internal.Pagination{
 			Offset: utils.ValueOr(offset, 0),
 			Limit:  utils.ValueOr(limit, 10),
 		},
 		Sort:     utils.ValueOr(sort, "DESC"),
 		Resolved: resolved,
-	}
-	reports, err := r.UserReportService.List(ctx, filter)
-	if err != nil {
-		return nil, err
-	}
-	return lo.ToSlicePtr(reports), nil
+	})
 }
 
 // Fields

--- a/internal/graphql/server.generated.go
+++ b/internal/graphql/server.generated.go
@@ -4257,7 +4257,7 @@ input InputUserReport {
     sort: String = "DESC"
   ): [UserReport!]! @hasRole(role: REVIEWER)
 
-  "Get a single user report, even if it's been resolved/deleted. Requires the "
+  "Get a single user report, even if it's been resolved/deleted."
   findUserReport(id: ID!): UserReport! @hasRole(role: REVIEWER)
 }
 `, BuiltIn: false},

--- a/internal/models.generated.go
+++ b/internal/models.generated.go
@@ -119,6 +119,10 @@ type Episode struct {
 	Urls []*EpisodeURL `json:"urls"`
 	// If the episode is the source episode for a `Template`, this will resolve to that template
 	Template *Template `json:"template"`
+	// List the user reports for the episode. Requires the REVIEWER role.
+	//
+	// > `@hasRole(role: REVIEWER)` - The user must have the `REVIEWER` role to query this property.
+	UserReports []*UserReport `json:"userReports"`
 }
 
 func (Episode) IsBaseModel() {}

--- a/internal/models.go
+++ b/internal/models.go
@@ -153,6 +153,7 @@ type UserReportsFilter struct {
 	Sort           string
 	ID             *uuid.UUID
 	Resolved       *bool
+	EpisodeID      *uuid.UUID
 	IncludeDeleted bool
 }
 

--- a/internal/postgres/user_reports_repo.go
+++ b/internal/postgres/user_reports_repo.go
@@ -38,6 +38,9 @@ func findUserReports(ctx context.Context, tx internal.Tx, filter internal.UserRe
 	if filter.Resolved != nil {
 		query.Where("resolved = ?", *filter.Resolved)
 	}
+	if filter.EpisodeID != nil {
+		query.Where("episode_id = ?", *filter.EpisodeID)
+	}
 	if filter.Pagination != nil {
 		query.Paginate(*filter.Pagination)
 	}


### PR DESCRIPTION
For example, grab all the other reports for an episode given a single report

```ts
{
  findUserReport(id: "31bd3838-49a5-4936-baa8-35041e93d255") {
    episode {
      userReports(resolved: false) {
        id
        message
        resolved
      }
    }
  }
}

```